### PR TITLE
Include pipeline metadata fields in generated schema

### DIFF
--- a/scripts/build-schemas.js
+++ b/scripts/build-schemas.js
@@ -206,6 +206,15 @@ const featureCollectionTemplate = (geometryTypeEnum, propertiesObj, dependencies
         format: 'date-time',
         type: 'string',
       },
+      pipelineVersion: {
+        additionalProperties: true,
+        properties: {},
+        type: 'object',
+      },
+      region: {
+        ...geometrySchemaFor(['MultiPolygon']),
+        description: 'MultiPolygon geometry object.',
+      },
       type: {
         title: 'Feature Collection',
         type: 'string',


### PR DESCRIPTION
## Summary
- add `pipelineVersion` and `region` properties to feature collection template so generated schemas include them

## Testing
- `node scripts/parse-osw-schema.js`
- `python test.py`

------
https://chatgpt.com/codex/tasks/task_e_68bab2229d488327bf4feec3c7f6b16e